### PR TITLE
Add a plugin that filters the Organization @type to NewsMediaOrganiza…

### DIFF
--- a/wp-content/plugins/wpseo-news-media-organization/.gitignore
+++ b/wp-content/plugins/wpseo-news-media-organization/.gitignore
@@ -1,0 +1,9 @@
+.DS_Store
+phpcs.xml
+phpunit.xml
+Thumbs.db
+wp-cli.local.yml
+node_modules/
+*.sql
+*.tar.gz
+*.zip

--- a/wp-content/plugins/wpseo-news-media-organization/readme.txt
+++ b/wp-content/plugins/wpseo-news-media-organization/readme.txt
@@ -1,0 +1,28 @@
+=== Wpseo News Media Organization ===
+Contributors: innlabs
+Donate link: https://inn.org/donate
+Tags: yoast, schema, news
+Requires at least: 4.5
+Tested up to: 5.4.1
+Stable tag: 0.1.0
+License: GPLv2 or later
+License URI: https://www.gnu.org/licenses/gpl-2.0.html
+
+Changes an organization's `@type` to `NewsMediaOrganization`
+
+== Description ==
+
+A thin implementation of https://schema.org/NewsMediaOrganization within the Yoast SEO plugin's Schema API, using the [`wpseo_schema_<$class>`](https://developer.yoast.com/features/schema/api/#change-a-graph-pieces-data) filter on the `Organization` class.
+
+
+== Installation ==
+
+1. Upload this plugin to the `/wp-content/plugins/` directory
+2. Activate the plugin through the 'Plugins' menu in WordPress
+3. The plugin requires no configuration.
+
+== Changelog ==
+
+= 0.1 =
+
+* Initial creation of the plugin

--- a/wp-content/plugins/wpseo-news-media-organization/wpseo-news-media-organization.php
+++ b/wp-content/plugins/wpseo-news-media-organization/wpseo-news-media-organization.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Plugin Name:     Yoast schema @type: NewsMediaOrganization
+ * Plugin URI:      https://github.com/INN/umbrella-publicsource
+ * Description:     Changes the schema.org @type for the site's Organization to NewsMediaOrganization
+ * Author:          INN Labs
+ * Author URI:      https://labs.inn.org
+ * Text Domain:     wpseo-news-media-organization
+ * Domain Path:     /languages
+ * Version:         0.1.0
+ *
+ * @package         Wpseo_News_Media_Organization
+ */
+
+/**
+ * Filter the organization @type to be NewsMediaOrganization
+ *
+ * A thin implementation of https://schema.org/NewsMediaOrganization within the Yoast SEO plugin's Schema API, using the [`wpseo_schema_<$class>`](https://developer.yoast.com/features/schema/api/#change-a-graph-pieces-data) filter on the `Organization` class.
+ * 
+ * @link https://github.com/INN/umbrella-publicsource/issues/50
+ * @link https://schema.org/NewsMediaOrganization
+ */
+add_filter( 'wpseo_schema_organization', function( $data ) {
+	$data['@type'] = 'NewsMediaOrganization';
+	return $data;
+} );


### PR DESCRIPTION
## Changes

This pull request makes the following changes:

- Adds a mini plugin

## Why

<!-- Why does this PR propose these changes? Take as much space as you need to explain. -->
<!-- If there are GitHub issues that this pull request addresses, please list them here. -->
For https://github.com/INN/umbrella-publicsource/issues/50

## Testing/Questions

Features that this PR affects:

- Yoast SEO's Schema.org output

<!-- If there are no questions, please remove the questions section. -->
Questions that need to be answered before merging:

- [x] Is this PR targeting the correct branch in this repository?
- [x] Does it work?
- [ ] Do we need to implement any other fields for this?
- [ ] How do we handle changes to Yoast's API in the future?

Steps to test this PR:

0. install and activate `wordpress-seo` Yoast
0. In Dashboard > SEO > Search Appearance, make sure the site type is Organization, not Person
0. View the source of various pages on the site: within the `ld+json` tag, the `@type` of the top-level organization-type object should be Organization, not one of its subtypes: https://schema.org/Organization#subtypes
1. Check out this branch
2. `wp plugin activate wpseo-news-media-organization`
3. View the source of those pages again: the `@type` should now be `NewsMediaOrganization`

## Additional information

INN Member/Labs Client requesting: PublicSource support Quicksign
